### PR TITLE
feat(GH-6): add auth, validation, and error handling

### DIFF
--- a/api/admin/posts.ts
+++ b/api/admin/posts.ts
@@ -14,17 +14,31 @@ function getPrisma() {
   return prisma;
 }
 
+function isAuthorized(req: VercelRequest): boolean {
+  const apiKey = req.headers['x-api-key'];
+  return apiKey === process.env.API_KEY;
+}
+
 export default async function handler(
   req: VercelRequest,
   res: VercelResponse
 ) {
+  if (!isAuthorized(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const prismaClient = getPrisma();
-  const posts = await prismaClient.post.findMany({
-    orderBy: { createdAt: 'desc' },
-  });
-  res.json(posts);
+  try {
+    const prismaClient = getPrisma();
+    const posts = await prismaClient.post.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json(posts);
+  } catch (error) {
+    console.error('Error fetching posts:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 }

--- a/api/analytics/view.ts
+++ b/api/analytics/view.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
+import { z } from 'zod';
 
 let prisma: PrismaClient;
 
@@ -14,6 +15,10 @@ function getPrisma() {
   return prisma;
 }
 
+const analyticsViewSchema = z.object({
+  postId: z.string().uuid(),
+});
+
 export default async function handler(
   req: VercelRequest,
   res: VercelResponse
@@ -22,14 +27,17 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { postId } = req.body;
-  if (!postId) {
-    return res.status(400).json({ error: 'postId required' });
+  try {
+    const { postId } = analyticsViewSchema.parse(req.body);
+    const pageView = await getPrisma().pageView.create({
+      data: { postId },
+    });
+    res.status(201).json(pageView);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: 'Validation error', details: error.errors });
+    }
+    console.error('Error tracking view:', error);
+    res.status(500).json({ error: 'Internal server error' });
   }
-
-  const prismaClient = getPrisma();
-  const pageView = await prismaClient.pageView.create({
-    data: { postId },
-  });
-  res.status(201).json(pageView);
 }

--- a/api/posts/[id].ts
+++ b/api/posts/[id].ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
+import { z } from 'zod';
 
 let prisma: PrismaClient;
 
@@ -18,6 +19,18 @@ function isUUID(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }
 
+function isAuthorized(req: VercelRequest): boolean {
+  const apiKey = req.headers['x-api-key'];
+  return apiKey === process.env.API_KEY;
+}
+
+const postUpdateSchema = z.object({
+  title: z.string().min(1).optional(),
+  content: z.string().min(1).optional(),
+  slug: z.string().min(1).optional(),
+  published: z.boolean().optional(),
+});
+
 export default async function handler(
   req: VercelRequest,
   res: VercelResponse
@@ -26,33 +39,59 @@ export default async function handler(
   const param = String(id);
 
   if (req.method === 'GET') {
-    const prismaClient = getPrisma();
-    const where = isUUID(param) 
-      ? { id: param } 
-      : { slug: param };
-    const post = await prismaClient.post.findUnique({ where });
-    if (!post) {
-      return res.status(404).json({ error: 'Post not found' });
+    try {
+      const prismaClient = getPrisma();
+      const where = isUUID(param) 
+        ? { id: param } 
+        : { slug: param };
+      const post = await prismaClient.post.findUnique({ where });
+      if (!post) {
+        return res.status(404).json({ error: 'Post not found' });
+      }
+      return res.json(post);
+    } catch (error) {
+      console.error('Error fetching post:', error);
+      return res.status(500).json({ error: 'Internal server error' });
     }
-    return res.json(post);
+  }
+
+  if (!isAuthorized(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
   }
 
   if (req.method === 'PUT') {
-    const prismaClient = getPrisma();
-    const { title, content, slug, published } = req.body;
-    const post = await prismaClient.post.update({
-      where: { id: param },
-      data: { title, content, slug, published },
-    });
-    return res.json(post);
+    if (!isUUID(param)) {
+      return res.status(400).json({ error: 'Invalid ID format' });
+    }
+    try {
+      const data = postUpdateSchema.parse(req.body);
+      const post = await getPrisma().post.update({
+        where: { id: param },
+        data,
+      });
+      return res.json(post);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Validation error', details: error.errors });
+      }
+      console.error('Error updating post:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   }
 
   if (req.method === 'DELETE') {
-    const prismaClient = getPrisma();
-    await prismaClient.post.delete({
-      where: { id: param },
-    });
-    return res.status(204).send(null);
+    if (!isUUID(param)) {
+      return res.status(400).json({ error: 'Invalid ID format' });
+    }
+    try {
+      await getPrisma().post.delete({
+        where: { id: param },
+      });
+      return res.status(204).send(null);
+    } catch (error) {
+      console.error('Error deleting post:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   }
 
   res.status(405).json({ error: 'Method not allowed' });

--- a/api/posts/index.ts
+++ b/api/posts/index.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
+import { z } from 'zod';
 
 let prisma: PrismaClient;
 
@@ -14,26 +15,53 @@ function getPrisma() {
   return prisma;
 }
 
+function isAuthorized(req: VercelRequest): boolean {
+  const apiKey = req.headers['x-api-key'];
+  return apiKey === process.env.API_KEY;
+}
+
+const postCreateSchema = z.object({
+  title: z.string().min(1),
+  content: z.string().min(1),
+  slug: z.string().min(1),
+  published: z.boolean().optional(),
+});
+
 export default async function handler(
   req: VercelRequest,
   res: VercelResponse
 ) {
-  const prismaClient = getPrisma();
-
   if (req.method === 'GET') {
-    const posts = await prismaClient.post.findMany({
-      where: { published: true },
-      orderBy: { createdAt: 'desc' },
-    });
-    return res.json(posts);
+    try {
+      const posts = await getPrisma().post.findMany({
+        where: { published: true },
+        orderBy: { createdAt: 'desc' },
+      });
+      return res.json(posts);
+    } catch (error) {
+      console.error('Error fetching posts:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+
+  if (!isAuthorized(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
   }
 
   if (req.method === 'POST') {
-    const { title, content, slug, published } = req.body;
-    const post = await prismaClient.post.create({
-      data: { title, content, slug, published: published ?? false },
-    });
-    return res.status(201).json(post);
+    try {
+      const data = postCreateSchema.parse(req.body);
+      const post = await getPrisma().post.create({
+        data: { ...data, published: data.published ?? false },
+      });
+      return res.status(201).json(post);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Validation error', details: error.errors });
+      }
+      console.error('Error creating post:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   }
 
   res.status(405).json({ error: 'Method not allowed' });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.1",
-    "zustand": "^5.0.12"
+    "zustand": "^5.0.12",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,13 +4,24 @@ import cors from 'cors';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
+import { z } from 'zod';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const API_KEY = process.env.API_KEY;
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
+
+const authMiddleware = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const key = req.headers['x-api-key'];
+  if (!API_KEY || key !== API_KEY) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  next();
+};
 
 app.use(cors());
 app.use(express.json());
@@ -19,83 +30,155 @@ app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
-app.get('/api/posts', async (_req, res) => {
-  const posts = await prisma.post.findMany({
-    where: { published: true },
-    orderBy: { createdAt: 'desc' },
-  });
-  res.json(posts);
-});
-
-app.get('/api/admin/posts', async (_req, res) => {
-  const posts = await prisma.post.findMany({
-    orderBy: { createdAt: 'desc' },
-  });
-  res.json(posts);
-});
-
-app.get('/api/posts/:slug', async (req, res) => {
-  const post = await prisma.post.findUnique({
-    where: { slug: req.params.slug },
-  });
-  if (!post) {
-    res.status(404).json({ error: 'Post not found' });
-    return;
+app.get('/api/posts', async (_req, res, next) => {
+  try {
+    const posts = await prisma.post.findMany({
+      where: { published: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json(posts);
+  } catch (error) {
+    next(error);
   }
-  res.json(post);
 });
 
-app.post('/api/posts', async (req, res) => {
-  const { title, content, slug, published } = req.body;
-  const post = await prisma.post.create({
-    data: { title, content, slug, published: published ?? false },
-  });
-  res.status(201).json(post);
-});
-
-app.put('/api/posts/:id', async (req, res) => {
-  const { title, content, slug, published } = req.body;
-  const post = await prisma.post.update({
-    where: { id: req.params.id },
-    data: { title, content, slug, published },
-  });
-  res.json(post);
-});
-
-app.delete('/api/posts/:id', async (req, res) => {
-  await prisma.post.delete({
-    where: { id: req.params.id },
-  });
-  res.status(204).send();
-});
-
-app.post('/api/analytics/view', async (req, res) => {
-  const { postId } = req.body;
-  if (!postId) {
-    res.status(400).json({ error: 'postId required' });
-    return;
+app.get('/api/admin/posts', authMiddleware, async (_req, res, next) => {
+  try {
+    const posts = await prisma.post.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json(posts);
+  } catch (error) {
+    next(error);
   }
-  const pageView = await prisma.pageView.create({
-    data: { postId },
-  });
-  res.status(201).json(pageView);
 });
 
-app.get('/api/analytics', async (_req, res) => {
-  const analytics = await prisma.post.findMany({
-    include: {
-      _count: {
-        select: { pageViews: true },
+app.get('/api/posts/:slug', async (req, res, next) => {
+  try {
+    const post = await prisma.post.findUnique({
+      where: { slug: req.params.slug },
+    });
+    if (!post) {
+      res.status(404).json({ error: 'Post not found' });
+      return;
+    }
+    res.json(post);
+  } catch (error) {
+    next(error);
+  }
+});
+
+const postCreateSchema = z.object({
+  title: z.string().min(1),
+  content: z.string().min(1),
+  slug: z.string().min(1),
+  published: z.boolean().optional(),
+});
+
+app.post('/api/posts', authMiddleware, async (req, res, next) => {
+  try {
+    const data = postCreateSchema.parse(req.body);
+    const post = await prisma.post.create({
+      data: { ...data, published: data.published ?? false },
+    });
+    res.status(201).json(post);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    next(error);
+  }
+});
+
+const postUpdateSchema = z.object({
+  title: z.string().min(1).optional(),
+  content: z.string().min(1).optional(),
+  slug: z.string().min(1).optional(),
+  published: z.boolean().optional(),
+});
+
+app.put('/api/posts/:id', authMiddleware, async (req, res, next) => {
+  try {
+    if (!/^[a-f0-9-]{36}$/i.test(req.params.id)) {
+      res.status(400).json({ error: 'Invalid ID format' });
+      return;
+    }
+    const data = postUpdateSchema.parse(req.body);
+    const post = await prisma.post.update({
+      where: { id: req.params.id },
+      data,
+    });
+    res.json(post);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    next(error);
+  }
+});
+
+app.delete('/api/posts/:id', authMiddleware, async (req, res, next) => {
+  try {
+    if (!/^[a-f0-9-]{36}$/i.test(req.params.id)) {
+      res.status(400).json({ error: 'Invalid ID format' });
+      return;
+    }
+    await prisma.post.delete({
+      where: { id: req.params.id },
+    });
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+const analyticsViewSchema = z.object({
+  postId: z.string().uuid(),
+});
+
+app.post('/api/analytics/view', async (req, res, next) => {
+  try {
+    const { postId } = analyticsViewSchema.parse(req.body);
+    const pageView = await prisma.pageView.create({
+      data: { postId },
+    });
+    res.status(201).json(pageView);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    next(error);
+  }
+});
+
+app.get('/api/analytics', async (_req, res, next) => {
+  try {
+    const analytics = await prisma.post.findMany({
+      include: {
+        _count: {
+          select: { pageViews: true },
+        },
       },
-    },
-  });
-  const result = analytics.map((post) => ({
-    id: post.id,
-    title: post.title,
-    slug: post.slug,
-    views: post._count.pageViews,
-  }));
-  res.json(result);
+    });
+    const result = analytics.map((post) => ({
+      id: post.id,
+      title: post.title,
+      slug: post.slug,
+      views: post._count.pageViews,
+    }));
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error('Server error:', err);
+  res.status(500).json({ error: 'Internal server error' });
 });
 
 app.listen(PORT, () => {

--- a/src/store/posts.ts
+++ b/src/store/posts.ts
@@ -22,6 +22,11 @@ interface PostsState {
 }
 
 const API_URL = '/api';
+const API_KEY = import.meta.env.VITE_API_KEY || '';
+
+const authHeaders = {
+  'x-api-key': API_KEY,
+};
 
 export const usePostsStore = create<PostsState>((set, get) => ({
   posts: [],
@@ -43,7 +48,9 @@ export const usePostsStore = create<PostsState>((set, get) => ({
   fetchAdminPosts: async () => {
     set({ loading: true, error: null });
     try {
-      const res = await fetch(`${API_URL}/admin/posts`);
+      const res = await fetch(`${API_URL}/admin/posts`, {
+        headers: authHeaders,
+      });
       if (!res.ok) throw new Error('Failed to fetch posts');
       const posts = await res.json();
       set({ posts, loading: false });
@@ -57,7 +64,10 @@ export const usePostsStore = create<PostsState>((set, get) => ({
     try {
       const res = await fetch(`${API_URL}/posts`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...authHeaders,
+        },
         body: JSON.stringify(post),
       });
       if (!res.ok) throw new Error('Failed to create post');
@@ -73,7 +83,10 @@ export const usePostsStore = create<PostsState>((set, get) => ({
     try {
       const res = await fetch(`${API_URL}/posts/${id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...authHeaders,
+        },
         body: JSON.stringify(post),
       });
       if (!res.ok) throw new Error('Failed to update post');
@@ -90,7 +103,10 @@ export const usePostsStore = create<PostsState>((set, get) => ({
   deletePost: async (id) => {
     set({ loading: true, error: null });
     try {
-      const res = await fetch(`${API_URL}/posts/${id}`, { method: 'DELETE' });
+      const res = await fetch(`${API_URL}/posts/${id}`, {
+        method: 'DELETE',
+        headers: authHeaders,
+      });
       if (!res.ok) throw new Error('Failed to delete post');
       set({ posts: get().posts.filter((p) => p.id !== id), loading: false });
     } catch (e) {


### PR DESCRIPTION
## Summary

Implements authentication, input validation, and error handling for all blog API endpoints.

### Changes

- **server/index.ts**: API key middleware, Zod schemas, try/catch, global error handler
- **api/admin/posts.ts**: Auth check + error handling
- **api/posts/index.ts**: Auth on POST + Zod validation
- **api/posts/[id].ts**: Auth on PUT/DELETE + UUID validation + Zod
- **api/analytics/view.ts**: Zod validation for postId
- **src/store/posts.ts**: Added `x-api-key` header via `VITE_API_KEY`
- **package.json**: Added `zod` dependency

### Testing

1. Set env vars in `.env`:
   ```
   API_KEY=your-secure-key
   VITE_API_KEY=your-secure-key
   ```

2. Set in Vercel project settings:
   - `API_KEY`
   - `VITE_API_KEY`

3. Test admin endpoints with `x-api-key` header:
   ```bash
   curl -H "x-api-key: your-secure-key" http://localhost:3001/api/admin/posts
   ```

### Breaking Change

Admin APIs (`POST`, `PUT`, `DELETE`) now require `x-api-key` header. Public read endpoints (`GET /api/posts`) remain unauthenticated.

Closes #6