### PR TITLE
chore(GH-9): add index on published field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,8 @@ model Post {
   content   String
   slug      String   @unique
   published Boolean  @default(false)
+
+  @@index([published])
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   pageViews PageView[]


### PR DESCRIPTION
## Summary

Add `@@index([published])` to Post model for faster filtering on published status.

### Changes

- `prisma/schema.prisma`: Added index on `published` field

### Testing

Run `npx prisma generate` to verify schema. The migration will apply the index on next deploy.

Closes #9