### PR TITLE
fix(GH-16,GH-19): add analytics auth and PageView index

### DIFF
--- a/api/analytics/index.ts
+++ b/api/analytics/index.ts
@@ -14,12 +14,21 @@ function getPrisma() {
   return prisma;
 }
 
+function isAuthorized(req: VercelRequest): boolean {
+  const apiKey = req.headers['x-api-key'];
+  return apiKey === process.env.API_KEY;
+}
+
 export default async function handler(
   req: VercelRequest,
   res: VercelResponse
 ) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!isAuthorized(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
   }
 
   const prismaClient = getPrisma();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,4 +24,6 @@ model PageView {
   postId    String
   post      Post    @relation(fields: [postId], references: [id], onDelete: Cascade)
   viewedAt  DateTime @default(now())
+
+  @@index([postId])
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -157,7 +157,7 @@ app.post('/api/analytics/view', async (req, res, next) => {
   }
 });
 
-app.get('/api/analytics', async (_req, res, next) => {
+app.get('/api/analytics', authMiddleware, async (_req, res, next) => {
   try {
     const analytics = await prisma.post.findMany({
       include: {


### PR DESCRIPTION
## Summary

Fix analytics security and performance.

### Changes

- `api/analytics/index.ts`: Add `isAuthorized()` check (GH-16)
- `server/index.ts`: Add `authMiddleware` to `/api/analytics` (GH-16)
- `prisma/schema.prisma`: Add `@@index([postId])` on PageView (GH-19)

### Testing

1. GET /api/analytics returns 401 without `x-api-key`
2. Analytics queries use postId index

Closes #16, Closes #19