### PR TITLE
fix: add navbar to public layout and improve error handling

### DIFF
--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -4,10 +4,18 @@ export function PublicLayout() {
   return (
     <div className="min-h-screen bg-white">
       <header className="border-b border-gray-200">
-        <div className="max-w-2xl mx-auto px-4 py-4">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center justify-between">
           <Link to="/" className="text-xl font-bold text-gray-900 hover:text-blue-600">
             MAF Blog
           </Link>
+          <nav className="flex gap-4">
+            <Link to="/" className="text-sm text-gray-600 hover:text-gray-900">
+              Home
+            </Link>
+            <Link to="/admin" className="text-sm text-gray-600 hover:text-gray-900">
+              Admin
+            </Link>
+          </nav>
         </div>
       </header>
       <main className="max-w-2xl mx-auto px-4 py-8">

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -10,11 +10,16 @@ interface AnalyticsData {
 export function Analytics() {
   const [data, setData] = useState<AnalyticsData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch('/api/analytics')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load analytics');
+        return res.json();
+      })
       .then(setData)
+      .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
 
@@ -22,6 +27,17 @@ export function Analytics() {
 
   if (loading) {
     return <div className="text-center py-8 text-gray-500">Loading...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-6">Analytics</h2>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+          Unable to load analytics: {error}
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Add navigation links (Home, Admin) to PublicLayout.tsx
- Add error handling to Analytics page to show friendly message on failure

## Changes
- src/components/PublicLayout.tsx - added navigation links
- src/pages/Analytics.tsx - added error state handling