### PR TITLE
fix(GH-24): add outputDirectory to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "npm run build",
   "framework": "vite",
   "installCommand": "npm install",
+  "outputDirectory": "dist",
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/((?!api|assets|_next).*)", "destination": "/index.html" }


### PR DESCRIPTION
## Summary
- Add outputDirectory: dist to vercel.json to fix 404 errors on deployed site

## Root Cause
The deployed site returned 404 for all routes because Vercel wasn't serving static assets.

## Fix
- Add outputDirectory: dist to vercel.json configuration

Closes #24